### PR TITLE
🐛 Fix : 판매자 닉네임 표시 오류 수정

### DIFF
--- a/assets/js/shop.js
+++ b/assets/js/shop.js
@@ -40,7 +40,7 @@ window.onload = async function bookList() {
         </ul>
       </div>
       <ul class="info">
-        <li class="saler">판매자 : ${parsed_payload.nickname} <!-- 판매자 별명 정보가 없어서 그대로 두었습니다. --></li>
+        <li class="saler">판매자 : ${bookData.writer_nickname}</li>
       </ul>
       <a class="check-item" href="${frontend}/assets/html/bookdetail.html?id=${bookData.id}/">상품 확인하기</a>
       </div>


### PR DESCRIPTION
판매자 닉네임이 현재 로그인한 사용자의 닉네임으로 표시되는 오류 수정했습니다.
확인해주세요!